### PR TITLE
Adding unshare back to fix hang issue

### DIFF
--- a/wrapper.c
+++ b/wrapper.c
@@ -34,7 +34,12 @@ int main(int argc, char *argv[], char *envp[]) {
     mknod("/dev/urandom", S_IFCHR | 0666, makedev(0x1, 0x9));
     chmod("/system/bin/linker64", 0755);
     chmod("/system/bin/main", 0755);
-
+    
+    if (unshare(CLONE_NEWPID)) {
+         perror("unshare");
+         return 1;
+     }
+    
     child_proc = fork();
     if (child_proc == -1) {
         perror("fork");


### PR DESCRIPTION
wrapper arm64 version is highly dependent on the child parent process structure. so without unshare the child process may never exit which willl cause the hang issue. If we really want to remove the unshare then we have to implement proper daemonization and child reaping logics on the code. Since then it can't be safely removed. 